### PR TITLE
fix: now handle the /update logic correctly

### DIFF
--- a/appointment-management/src/main/java/org/dljl/controller/AppointmentController.java
+++ b/appointment-management/src/main/java/org/dljl/controller/AppointmentController.java
@@ -104,13 +104,13 @@ public class AppointmentController {
    */
   // Update an appointment
   @PutMapping("/update")
-  public ResponseEntity<Appointment> updateAppointment(
+  public ResponseEntity<?> updateAppointment(
       @RequestBody UpdateAppointmentDto appointmentDto) {
     try {
       Appointment updatedAppointment = appointmentService.updateAppointment(appointmentDto);
       return ResponseEntity.ok(updatedAppointment);
     } catch (IllegalArgumentException e) {
-      return ResponseEntity.badRequest().body(null);
+      return ResponseEntity.badRequest().body(e.getMessage());
     }
   }
 

--- a/appointment-management/src/main/java/org/dljl/service/impl/AppointmentServiceImpl.java
+++ b/appointment-management/src/main/java/org/dljl/service/impl/AppointmentServiceImpl.java
@@ -128,19 +128,29 @@ public class AppointmentServiceImpl implements AppointmentService {
 
   @Override
   public Appointment updateAppointment(UpdateAppointmentDto appointmentDto) {
-    int conflictCount =
-        appointmentMapper.checkUpdateTimeConflict(
-            appointmentDto.getAppointmentId(),
-            appointmentDto.getStartDateTime().truncatedTo(ChronoUnit.SECONDS),
-            appointmentDto.getEndDateTime().truncatedTo(ChronoUnit.SECONDS));
-
-    if (conflictCount != 0) {
-      throw new IllegalArgumentException(
-          "The selected time slot conflicts with an existing appointment.");
-    }
 
     if (appointmentDto.getAppointmentId() == null) {
       throw new IllegalArgumentException("Appointment ID is required for updating an appointment.");
+    }
+    if (appointmentDto.getStartDateTime() != null || appointmentDto.getEndDateTime() != null) {
+      Appointment originalAppointment = getAppointment(appointmentDto.getAppointmentId());
+      if (appointmentDto.getStartDateTime() == null) {
+        appointmentDto.setStartDateTime(originalAppointment.getStartDateTime());
+      }
+      if (appointmentDto.getEndDateTime() == null) {
+        appointmentDto.setEndDateTime(originalAppointment.getEndDateTime());
+      }
+
+      int conflictCount =
+          appointmentMapper.checkUpdateTimeConflict(
+              appointmentDto.getAppointmentId(),
+              appointmentDto.getStartDateTime().truncatedTo(ChronoUnit.SECONDS),
+              appointmentDto.getEndDateTime().truncatedTo(ChronoUnit.SECONDS));
+
+      if (conflictCount != 0) {
+        throw new IllegalArgumentException(
+            "The updated time slot conflicts with an existing appointment or blocked time.");
+      }
     }
 
     appointmentMapper.updateAppointment(appointmentDto);

--- a/appointment-management/src/main/resources/application.properties
+++ b/appointment-management/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # MySQL Database Configuration
 spring.datasource.url=jdbc:mysql://localhost:3306/appointments_db
 spring.datasource.username=root
-spring.datasource.password=Ly89097877
+spring.datasource.password=dbuserdbuser
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # MyBatis Configuration
 mybatis.config-location=classpath:mybatis-config.xml


### PR DESCRIPTION
when there was no change in time in /update, service do not check for time conflict anymore. If only one of the end/start datetime changed, will automatically assign the unchanged datetime to original, and check for conflict.