### PR TITLE
Client ID Generation Fix. Delete Block Implementation. 

### DIFF
--- a/appointment-management/src/main/java/org/dljl/controller/AppointmentController.java
+++ b/appointment-management/src/main/java/org/dljl/controller/AppointmentController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,15 +26,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * The type Appointment controller.
- */
+/** The type Appointment controller. */
 @RestController
 @RequestMapping("/appointments")
 public class AppointmentController {
 
-  @Autowired
-  private AppointmentService appointmentService;
+  @Autowired private AppointmentService appointmentService;
 
   /**
    * Create appointment response entity.
@@ -104,8 +102,7 @@ public class AppointmentController {
    */
   // Update an appointment
   @PutMapping("/update")
-  public ResponseEntity<?> updateAppointment(
-      @RequestBody UpdateAppointmentDto appointmentDto) {
+  public ResponseEntity<?> updateAppointment(@RequestBody UpdateAppointmentDto appointmentDto) {
     try {
       Appointment updatedAppointment = appointmentService.updateAppointment(appointmentDto);
       return ResponseEntity.ok(updatedAppointment);
@@ -128,6 +125,26 @@ public class AppointmentController {
       return ResponseEntity.ok("Appointment cancelled successfully.");
     } else {
       return ResponseEntity.badRequest().body("Appointment not found or already cancelled.");
+    }
+  }
+
+  /**
+   * Delete a block entity. This will permanently delete a block from database to avoid unnecessary
+   * storage usage. This can potentially be used on appointment as well but do so will result in
+   * loss of user history. We did not enforce this API to be used on block only to give developer
+   * full control, but use carefully.
+   *
+   * @param id the block id
+   * @return the response entity
+   */
+  // Cancel an appointment
+  @DeleteMapping("/deleteBlock/{id}")
+  public ResponseEntity<String> deleteBlock(@PathVariable Long id) {
+    boolean isCancelled = appointmentService.deleteBlock(id);
+    if (isCancelled) {
+      return ResponseEntity.ok("Block cancelled successfully.");
+    } else {
+      return ResponseEntity.badRequest().body("Block not found or already deleted.");
     }
   }
 
@@ -165,7 +182,7 @@ public class AppointmentController {
   /**
    * Gets appointments by provider and date.
    *
-   * @param providerId      the provider id
+   * @param providerId the provider id
    * @param appointmentDate the appointment date
    * @return the appointments by provider and date
    */
@@ -174,7 +191,7 @@ public class AppointmentController {
   public ResponseEntity<List<Appointment>> getAppointmentsByProviderAndDate(
       @PathVariable("providerId") Long providerId,
       @PathVariable("appointmentDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-      LocalDate appointmentDate) {
+          LocalDate appointmentDate) {
     List<Appointment> appointments =
         appointmentService.getAppointmentsByProviderAndDate(providerId, appointmentDate);
     return ResponseEntity.ok(appointments);
@@ -183,7 +200,7 @@ public class AppointmentController {
   /**
    * Gets available time intervals.
    *
-   * @param providerId      the provider id
+   * @param providerId the provider id
    * @param appointmentDate the appointment date
    * @return the available time intervals
    */
@@ -192,7 +209,7 @@ public class AppointmentController {
   public ResponseEntity<List<List<LocalDateTime>>> getAvailableTimeIntervals(
       @PathVariable("providerId") Long providerId,
       @PathVariable("appointmentDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-      LocalDate appointmentDate) {
+          LocalDate appointmentDate) {
     List<List<LocalDateTime>> availableTimeIntervals =
         appointmentService.getAvailableTimeIntervals(providerId, appointmentDate);
     return ResponseEntity.ok(availableTimeIntervals);
@@ -202,7 +219,7 @@ public class AppointmentController {
    * Gets appointment history.
    *
    * @param providerId the provider id
-   * @param userId     the user id
+   * @param userId the user id
    * @return the appointment history
    */
   @GetMapping("/history")

--- a/appointment-management/src/main/java/org/dljl/controller/ClientController.java
+++ b/appointment-management/src/main/java/org/dljl/controller/ClientController.java
@@ -2,7 +2,7 @@ package org.dljl.controller;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,20 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClientController {
 
   /**
-   * Endpoint to register a new client. This endpoint generates a unique client ID using UUID and
-   * returns it in the response. It also provides a message instructing the client to save the
-   * generated ID.
+   * Endpoint to register a new client. This endpoint generates a unique client ID using a
+   * combination of the current timestamp and random numbers to avoid collisions. It returns the
+   * client ID as a long and a message instructing the client to save the generated ID.
    *
    * @return ResponseEntity containing a map with the generated client ID and an advisory message.
    *     The HTTP status code for the response is 201 (Created).
    */
   @PostMapping("/registerClient")
-  public ResponseEntity<Map<String, String>> registerClient() {
-    // Generate UUID for the client ID
-    String clientId = UUID.randomUUID().toString();
+  public ResponseEntity<Map<String, Object>> registerClient() {
+    // Generate unique client ID using current timestamp and random number
+    long currentTimeMillis = System.currentTimeMillis();
+    long randomPart = ThreadLocalRandom.current().nextLong(1000, 9999);
+    long clientId = currentTimeMillis * 10000 + randomPart;
 
     // Prepare response with client ID and message
-    Map<String, String> response = new HashMap<>();
+    Map<String, Object> response = new HashMap<>();
     response.put("client_id", clientId);
     response.put(
         "message",

--- a/appointment-management/src/main/java/org/dljl/mapper/AppointmentMapper.java
+++ b/appointment-management/src/main/java/org/dljl/mapper/AppointmentMapper.java
@@ -97,4 +97,13 @@ public interface AppointmentMapper {
    */
   // Get all history by given provider and user
   List<Appointment> findAppointmentsByProviderAndUser(Long providerId, Long userId);
+
+  /**
+   * Delete block.
+   *
+   * @param id the id
+   * @return num rows affected
+   */
+  // delete the block permanently
+  int deleteBlock(Long id);
 }

--- a/appointment-management/src/main/java/org/dljl/service/AppointmentService.java
+++ b/appointment-management/src/main/java/org/dljl/service/AppointmentService.java
@@ -45,12 +45,20 @@ public interface AppointmentService {
   Appointment updateAppointment(UpdateAppointmentDto appointmentDto);
 
   /**
-   * Cancel appointment boolean.
+   * Cancel appointment.
    *
    * @param id the id
    * @return the boolean
    */
   boolean cancelAppointment(Long id);
+
+  /**
+   * Delete block.
+   *
+   * @param id the id
+   * @return the boolean whether block is deleted.
+   */
+  boolean deleteBlock(Long id);
 
   /**
    * Gets appointment.

--- a/appointment-management/src/main/java/org/dljl/service/impl/AppointmentServiceImpl.java
+++ b/appointment-management/src/main/java/org/dljl/service/impl/AppointmentServiceImpl.java
@@ -184,6 +184,15 @@ public class AppointmentServiceImpl implements AppointmentService {
   }
 
   @Override
+  public boolean deleteBlock(Long id) {
+    // Call the mapper to cancel the appointment
+    int rowsAffected = appointmentMapper.deleteBlock(id);
+
+    // If rowsAffected is 1, the appointment was successfully cancelled; otherwise, it was not found
+    return rowsAffected == 1;
+  }
+
+  @Override
   public List<List<LocalDateTime>> getAvailableTimeIntervals(Long providerId, LocalDate date) {
 
     List<Appointment> appointments =

--- a/appointment-management/src/main/resources/mybatis-mappers/AppointmentMapper.xml
+++ b/appointment-management/src/main/resources/mybatis-mappers/AppointmentMapper.xml
@@ -157,5 +157,9 @@
         WHERE appointment_id = #{appointmentId}
     </update>
 
-
+    <!-- Cancel an appointment by setting status to 'cancelled' -->
+    <delete id="deleteBlock" parameterType="Long">
+        DELETE FROM appointments
+        WHERE appointment_id = #{id}
+    </delete>
 </mapper>

--- a/appointment-management/src/test/java/org/dljl/service/AppointmentServiceTest.java
+++ b/appointment-management/src/test/java/org/dljl/service/AppointmentServiceTest.java
@@ -263,7 +263,7 @@ public class AppointmentServiceTest {
         () -> appointmentService.updateAppointment(updateDto)
     );
 
-    assertEquals("The selected time slot conflicts with an existing appointment.",
+    assertEquals("The updated time slot conflicts with an existing appointment or blocked time.",
         exception.getMessage());
   }
 
@@ -281,7 +281,7 @@ public class AppointmentServiceTest {
     });
 
     assertEquals(
-        "The selected time slot conflicts with an existing appointment.",
+        "The updated time slot conflicts with an existing appointment or blocked time.",
         exception.getMessage());
   }
 


### PR DESCRIPTION
Client ID was previously string but require long. Come up with new method to generate unique long type id for clients. Delete Block can now be used to delete blocks in database to avoid unnecessary storage usage. 